### PR TITLE
Add bilingual README documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,97 @@
+# OpenAI Cost Optimal Gateway
+
+[English](README.md) | [中文](README.zh.md)
+
+OpenAI Cost Optimal Gateway is a Go service that proxies OpenAI- and Anthropic-compatible API requests to multiple upstream providers. It adds rule-driven routing so that traffic can be steered to the most cost-effective provider while keeping API compatibility with official OpenAI and Anthropic clients.
+
+## Features
+
+- **Drop-in API gateway** &mdash; Exposes `/v1/chat/completions`, `/v1/responses`, `/v1/messages`, and `/v1/models` endpoints that mimic OpenAI or Anthropic semantics so existing SDKs keep working.
+- **Provider abstraction** &mdash; Supports any provider that implements the same REST contract, including OpenAI, Azure OpenAI, Anthropic, and third-party resellers.
+- **Rule-based routing** &mdash; Evaluates configurable expressions (powered by [`expr`](https://github.com/expr-lang/expr)) to pick the best provider/model combination per request.
+- **Token-aware decisions** &mdash; Counts tokens per request to drive routing logic, enabling automatic fallbacks when prompts exceed context windows.
+- **Gateway API keys** &mdash; Protects the gateway itself with shared API keys that clients must provide via the `Authorization` header.
+- **Observability helpers** &mdash; Includes structured logging and panic recovery middleware.
+
+## Architecture Overview
+
+```text
+client ──► gateway server ──► selected provider (OpenAI/Azure/Anthropic/...)
+             │
+             └─► routing rules + token counting
+```
+
+The service boots with a configuration file that defines:
+
+- Gateway listen address and API keys
+- A list of providers with base URLs, access tokens, and optional headers/timeouts
+- Logical models with default provider order
+- Optional routing rules that override provider/model pairs when an expression matches
+
+The gateway uses this configuration to build an in-memory routing table. Requests are authenticated, the body is inspected to resolve the `model` name, routing rules are evaluated, and the request is forwarded to the chosen upstream provider.
+
+## Getting Started
+
+### Prerequisites
+
+- Go 1.21+
+- Access tokens for the providers you plan to proxy
+
+### Clone and build
+
+```bash
+git clone https://github.com/mylxsw/openai-cost-optimal-gateway.git
+cd openai-cost-optimal-gateway
+go build ./cmd/gateway
+```
+
+### Configure the gateway
+
+Copy `config.example.yaml` and edit it to fit your environment:
+
+```bash
+cp config.example.yaml config.yaml
+```
+
+Key sections of the configuration:
+
+- `listen`: Address the HTTP server binds to.
+- `api_keys`: Gateway API keys clients must present. Multiple keys are supported.
+- `providers`: Upstream providers, each with `id`, `base_url`, `access_token`, optional `headers`, and `timeout`.
+- `models`: Logical models exposed by the gateway, listing default providers and optional `rules`.
+- `rules`: Expressions evaluated with the following environment:
+  - `TokenCount`: Counted tokens for the request payload.
+  - `Model`: Requested model name.
+  - `Path`: Request path (e.g., `/v1/chat/completions`).
+
+Rules can return either an array of provider overrides or an object map for convenience. Overrides accept an `id` (matching a provider) and an optional `model` that replaces the outbound `model` field.
+
+### Run the gateway
+
+```bash
+./gateway -config config.yaml
+```
+
+The server listens on the configured `listen` address. Clients must include `Authorization: Bearer <gateway-api-key>` and can call the standard OpenAI endpoints using the logical models defined in `config.yaml`.
+
+## API Endpoints
+
+| Path | Method | Description |
+| --- | --- | --- |
+| `/healthz` | GET | Health probe returning `ok` when the service is running. |
+| `/v1/chat/completions` | POST | Proxies OpenAI Chat Completions requests. |
+| `/v1/responses` | POST | Proxies OpenAI Assistants Responses requests. |
+| `/v1/messages` | POST | Proxies Anthropic Messages requests. |
+| `/v1/models` | GET | Lists logical models exposed by the gateway. |
+
+## Development
+
+Run unit tests before submitting changes:
+
+```bash
+go test ./...
+```
+
+## License
+
+This project is licensed under the [MIT License](LICENSE).

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,0 +1,97 @@
+# OpenAI 成本最优网关
+
+[English](README.md) | [中文](README.zh.md)
+
+OpenAI 成本最优网关是一个使用 Go 编写的代理服务，可以将兼容 OpenAI 与 Anthropic 的 API 请求转发到多个上游服务提供方。通过自定义的规则路由机制，网关能够在保持与官方 SDK 兼容的同时，将流量引导到成本最合适的提供方。
+
+## 功能特性
+
+- **即插即用的 API 网关** —— 暴露 `/v1/chat/completions`、`/v1/responses`、`/v1/messages` 与 `/v1/models` 等端点，行为与 OpenAI / Anthropic 接口保持一致，现有客户端可直接接入。
+- **统一的提供方抽象** —— 支持任何遵循相同 REST 协议的提供方，包括 OpenAI、Azure OpenAI、Anthropic 以及第三方代理商。
+- **基于规则的路由** —— 使用 [`expr`](https://github.com/expr-lang/expr) 表达式评估路由规则，根据请求动态挑选最优的提供方与模型组合。
+- **基于 Token 的决策** —— 统计请求中的 Token 数量，将其作为路由条件，帮助在输入超出上下文长度时自动切换模型或提供方。
+- **网关级 API Key** —— 网关自身通过共享的 API Key 鉴权，客户端需在 `Authorization` 请求头中携带。
+- **观测性增强** —— 内置结构化日志与 panic 恢复中间件，便于排查问题。
+
+## 架构概览
+
+```text
+client ──► gateway server ──► selected provider (OpenAI/Azure/Anthropic/...)
+             │
+             └─► routing rules + token counting
+```
+
+服务启动时会加载配置文件，该文件定义：
+
+- 网关监听地址与访问 API Key
+- 上游提供方列表，包含基础 URL、访问令牌以及可选的请求头/超时时间
+- 对外暴露的逻辑模型以及默认的提供方顺序
+- 可选的路由规则，用于在表达式命中时覆盖默认的提供方/模型
+
+网关根据这些配置构建内存中的路由表。请求在进入网关时会先通过鉴权，然后读取请求体中的 `model` 字段，依次评估路由规则，最终将请求转发到被选中的上游提供方。
+
+## 快速开始
+
+### 环境要求
+
+- Go 1.21 及以上版本
+- 计划接入的各上游服务提供方访问令牌
+
+### 克隆与编译
+
+```bash
+git clone https://github.com/mylxsw/openai-cost-optimal-gateway.git
+cd openai-cost-optimal-gateway
+go build ./cmd/gateway
+```
+
+### 配置网关
+
+复制示例配置文件并按实际情况修改：
+
+```bash
+cp config.example.yaml config.yaml
+```
+
+配置文件的关键字段：
+
+- `listen`：HTTP 服务监听的地址。
+- `api_keys`：访问网关所需的 API Key，可配置多个。
+- `providers`：上游提供方列表，每项包含 `id`、`base_url`、`access_token` 以及可选的 `headers`、`timeout`。
+- `models`：网关对外暴露的逻辑模型，包含默认提供方和可选的 `rules`。
+- `rules`：基于以下环境变量的表达式：
+  - `TokenCount`：请求推测出的 Token 数。
+  - `Model`：请求的模型名称。
+  - `Path`：请求路径（例如 `/v1/chat/completions`）。
+
+规则可以返回提供方覆盖数组，或使用对象映射的简写形式。每个覆盖项需指定提供方 `id`，并可选指定新的下游 `model`。
+
+### 启动网关
+
+```bash
+./gateway -config config.yaml
+```
+
+服务会监听配置的地址。客户端需在请求头中携带 `Authorization: Bearer <gateway-api-key>`，即可使用标准 OpenAI 接口调用配置中的逻辑模型。
+
+## API 接口
+
+| Path | Method | 描述 |
+| --- | --- | --- |
+| `/healthz` | GET | 健康检查接口，返回 `ok` 表示运行正常。 |
+| `/v1/chat/completions` | POST | 代理 OpenAI Chat Completions 请求。 |
+| `/v1/responses` | POST | 代理 OpenAI Assistants Responses 请求。 |
+| `/v1/messages` | POST | 代理 Anthropic Messages 请求。 |
+| `/v1/models` | GET | 返回网关暴露的逻辑模型列表。 |
+
+## 开发说明
+
+提交代码前建议先运行单元测试：
+
+```bash
+go test ./...
+```
+
+## 许可证
+
+本项目基于 [MIT License](LICENSE) 开源。


### PR DESCRIPTION
## Summary
- add an English README that documents the gateway architecture, configuration, and usage
- provide a Chinese translation in README.zh.md with cross-links between the two files

## Testing
- go test ./... *(fails: module download blocked by proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68d3db7e556c832199a6802e391595a4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive README outlining the project overview, key features, architecture, prerequisites, setup/build steps, configuration (config.yaml), run instructions, API endpoints, routing rules, token-based decisions, gateway API keys, observability, development/testing, and licensing.
  * Introduced a Chinese README (README.zh.md) mirroring the English document, covering the same topics for multilingual accessibility.
  * No code changes; documentation-only update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->