### PR TITLE
Support provider aliases and default provider fallback

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -5,6 +5,7 @@
 # - Rule expressions accessing TokenCount/Model/Path to reroute traffic and rewrite downstream model IDs
 listen: 0.0.0.0:8000
 debug: true
+default-provider: openai-official
 
 api_keys:
   - sk-admin-gateway-key
@@ -45,9 +46,11 @@ providers:
 models:
   - model: gpt-4o
     providers:
-      - openai-official
-      - azure-gpt4o
-      - reseller-gpt4o
+      - provider: openai-official
+      - provider: azure-gpt4o
+        model: gpt-4o
+      - provider: reseller-gpt4o
+        model: openai/gpt-4o
     rules:
       - rule: TokenCount > 12000
         providers:
@@ -61,8 +64,8 @@ models:
           cloudflare-proxy: openai/gpt-4o-mini
   - model: claude-3-5-sonnet
     providers:
-      - anthropic-claude
-      - openai-official
+      - provider: anthropic-claude
+      - provider: openai-official
     rules:
       - rule: Path == "/v1/chat/completions"
         providers:


### PR DESCRIPTION
## Summary
- allow configuring provider-specific model aliases for default model routing and keep rule overrides intact
- try configured providers sequentially and fall back to the configured default provider when a model is not defined
- merge default provider models into the /v1/models response and document the new options in the example config

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d4ad1f046c83219bec172a6b996ea9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Add support for a default provider used for model discovery and fallback routing.
  - Automatically merge models fetched from the default provider with local models, avoiding duplicates.
  - Proxy requests to the default provider when a requested model isn’t configured.
  - Support both legacy string-based and new map-based provider entries in configuration.

- Documentation
  - Update example configuration to introduce default-provider and map-based provider syntax, including embedded model fields where applicable.

- Refactor
  - Simplify provider selection by sourcing directly from each model’s configured providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->