### PR TITLE
Handle provider bad request fallbacks

### DIFF
--- a/internal/gateway/gateway_test.go
+++ b/internal/gateway/gateway_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/mylxsw/openai-cost-optimal-gateway/internal/config"
@@ -106,18 +107,21 @@ func TestProxyRetriesProviderOnContentFilter(t *testing.T) {
 	}
 }
 
-func TestProxyDoesNotRetryOnNonRetryableClientError(t *testing.T) {
-	secondCalls := 0
-	second := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		secondCalls++
-		t.Fatalf("second provider should not be called")
-	}))
-	t.Cleanup(second.Close)
-
+func TestProxyRetriesOnBadRequestWithoutSpecialError(t *testing.T) {
+	firstCalls := 0
 	first := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		firstCalls++
 		http.Error(w, `{"error":"bad_request"}`, http.StatusBadRequest)
 	}))
 	t.Cleanup(first.Close)
+
+	secondCalls := 0
+	second := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		secondCalls++
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"ok"}`))
+	}))
+	t.Cleanup(second.Close)
 
 	cfg := &config.Config{
 		Providers: []config.ProviderConfig{
@@ -139,10 +143,46 @@ func TestProxyDoesNotRetryOnNonRetryableClientError(t *testing.T) {
 
 	gw.Proxy(rec, req, RequestTypeChatCompletions)
 
-	if secondCalls != 0 {
-		t.Fatalf("expected second provider not to be called, got %d", secondCalls)
+	if firstCalls != 1 {
+		t.Fatalf("expected first provider to be called once, got %d", firstCalls)
 	}
+	if secondCalls != 1 {
+		t.Fatalf("expected second provider to be called once, got %d", secondCalls)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rec.Code)
+	}
+}
+
+func TestProxyReturnsBadRequestWhenAllProvidersFail(t *testing.T) {
+	first := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"error":"bad_request"}`, http.StatusBadRequest)
+	}))
+	t.Cleanup(first.Close)
+
+	cfg := &config.Config{
+		Providers: []config.ProviderConfig{
+			{ID: "first", BaseURL: first.URL, AccessToken: "token1"},
+		},
+		Models: []config.ModelConfig{
+			{Name: "gpt-3.5", Providers: []config.ModelProvider{{ID: "first"}}},
+		},
+	}
+
+	gw, err := New(cfg)
+	if err != nil {
+		t.Fatalf("create gateway: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader([]byte(`{"model":"gpt-3.5"}`)))
+	rec := httptest.NewRecorder()
+
+	gw.Proxy(rec, req, RequestTypeChatCompletions)
+
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("expected status 400, got %d", rec.Code)
+	}
+	if strings.TrimSpace(rec.Body.String()) == "" {
+		t.Fatalf("expected response body, got empty")
 	}
 }


### PR DESCRIPTION
## Summary
- retry the next provider when a provider responds with a 400 by treating bad requests as retryable responses
- preserve provider error payloads by carrying response headers and body in retryable errors so clients still receive the upstream 400 when no other provider succeeds
- cover the new behavior with tests for both multi-provider retries and single-provider fallbacks

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d528a4ae848321a67159c9f8dc1a20